### PR TITLE
Add make targets for OSX/darwin builds and zips for github releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 bin/
+release/
 .vscode


### PR DESCRIPTION
I added make targets to generate binaries for OSX/darwin (amd64 and arm64), and also generate zips for more convenient GitHub releases:
```
sevagh:roc $ make clean release_zips
...
sevagh:roc $ ls release/
roc-darwin-amd64.zip  roc-darwin-arm64.zip  roc-linux-amd64.zip
```